### PR TITLE
CORS header feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,4 @@ The following environment variables must be configured:
 * `MU_SECRET_KEY_BASE`: base string of at least 64 bytes used to generate secret keys
 * `MU_ENCRYPTION_SALT`: a salt used with `MU_SECRET_KEY_BASE` to generate a key for encrypting/decrypting a cookie
 * `MU_SIGNING_SALT`: a salt used with `MU_SECRET_KEY_BASE` to generate a key for signing/verifying a cookie
+* `MU_CORS_HEADER`: value of the `Access-Control-Allow-Origin` header if it should be set by the identifier

--- a/config/config.exs
+++ b/config/config.exs
@@ -18,7 +18,8 @@ use Mix.Config
 config :proxy,
   encryption_salt: System.get_env("MU_ENCRYPTION_SALT") || "${MU_ENCRYPTION_SALT}",
   signing_salt: System.get_env("MU_SIGNING_SALT") || "${MU_SIGNING_SALT}",
-  secret_key_base: System.get_env("MU_SECRET_KEY_BASE") || "${MU_SECRET_KEY_BASE}"
+  secret_key_base: System.get_env("MU_SECRET_KEY_BASE") || "${MU_SECRET_KEY_BASE}",
+  cors_header: System.get_env("MU_CORS_HEADER")
 
 # It is also possible to import configuration files, relative to this
 # directory. For example, you can emulate configuration per environment

--- a/lib/proxy.ex
+++ b/lib/proxy.ex
@@ -93,7 +93,13 @@ defmodule Proxy do
 
   defp add_cors_header( headers ) do
     # Adds the CORS header to the list of headers
-    put_new_key( headers, "Access-Control-Allow-Origin", "*" )
+    cors_header = Application.get_env(:proxy, :cors_header)
+
+    if cors_header do
+      put_new_key( headers, "Access-Control-Allow-Origin", cors_header )
+    else
+      headers
+    end
   end
 
   def dispatch(conn, _opts) do

--- a/lib/proxy.ex
+++ b/lib/proxy.ex
@@ -52,6 +52,7 @@ defmodule Proxy do
           |> List.keydelete( "cache-keys", 0 )
           |> List.keydelete( "clear-keys", 0 )
           |> augment_cache_clear_headers
+          |> add_cors_header
 
         { new_headers, state, response_conn }
       end,
@@ -88,6 +89,11 @@ defmodule Proxy do
         |> put_new_key( "cache-control", "no-cache" )
       _ -> headers
     end
+  end
+
+  defp add_cors_header( headers ) do
+    # Adds the CORS header to the list of headers
+    put_new_key( headers, "Access-Control-Allow-Origin", "*" )
   end
 
   def dispatch(conn, _opts) do


### PR DESCRIPTION
Allows `Access-Control-Allow-Origin` header to be set through the `MU_CORS_HEADER` environment variable.

When this variable is set, and the backend service does not set the `Access-Control-Allow-Origin` header, then the identifier will set the default value provided in the `MU_CORS_HEADER` environment variable.

The name `MU_CORS_HEADER` is chosen as that is likely what people will be looking for.