### PR TITLE
Default MU_AUTH_ALLOWED_GROUPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,4 @@ The following environment variables must be configured:
 * `MU_ENCRYPTION_SALT`: a salt used with `MU_SECRET_KEY_BASE` to generate a key for encrypting/decrypting a cookie
 * `MU_SIGNING_SALT`: a salt used with `MU_SECRET_KEY_BASE` to generate a key for signing/verifying a cookie
 * `MU_CORS_HEADER`: value of the `Access-Control-Allow-Origin` header if it should be set by the identifier
+* `DEFAULT_MU_AUTH_ALLOWED_GROUPS`: string used as default `MU_AUTH_ALLOWED_GROUPS` for sessions which don't contain these groups yet. (eg: `"[{\"variables\":[],\"name\":\"public\"}]"`)

--- a/config/config.exs
+++ b/config/config.exs
@@ -19,7 +19,8 @@ config :proxy,
   encryption_salt: System.get_env("MU_ENCRYPTION_SALT") || "${MU_ENCRYPTION_SALT}",
   signing_salt: System.get_env("MU_SIGNING_SALT") || "${MU_SIGNING_SALT}",
   secret_key_base: System.get_env("MU_SECRET_KEY_BASE") || "${MU_SECRET_KEY_BASE}",
-  cors_header: System.get_env("MU_CORS_HEADER")
+  cors_header: System.get_env("MU_CORS_HEADER"),
+  default_mu_auth_allowed_groups: System.get_env("DEFAULT_MU_AUTH_ALLOWED_GROUPS")
 
 # It is also possible to import configuration files, relative to this
 # directory. For example, you can emulate configuration per environment

--- a/lib/proxy.ex
+++ b/lib/proxy.ex
@@ -38,9 +38,12 @@ defmodule Proxy do
 
         response_conn =
           case authorization do
-            "CLEAR" -> Plug.Conn.delete_session( response_conn, :mu_auth_allowed_groups )
+            "CLEAR" ->
+              # Set CLEAR as the authorization group so we can pick it
+              # up on the next request
+              Plug.Conn.put_session( response_conn, :mu_auth_allowed_groups, authorization )
             nil -> response_conn
-            _ -> Plug.Conn.put_session(response_conn, :mu_auth_allowed_groups, authorization)
+            _ -> Plug.Conn.put_session( response_conn, :mu_auth_allowed_groups, authorization )
           end
 
         # new_headers = [ {"mu-session-id", Plug.Conn.get_session(conn, :proxy_user_id) } | headers ]
@@ -144,6 +147,8 @@ defmodule Proxy do
     default_allowed_groups = Application.get_env(:proxy, :default_mu_auth_allowed_groups)
 
     headers_with_authorization = cond do
+      authorization_groups == "CLEAR" ->
+        new_headers
       authorization_groups ->
         [ { "mu-auth-allowed-groups", authorization_groups } | new_headers ]
       default_allowed_groups ->

--- a/lib/proxy.ex
+++ b/lib/proxy.ex
@@ -141,15 +141,18 @@ defmodule Proxy do
         | clean_headers ]
 
     authorization_groups = Plug.Conn.get_session( conn, :mu_auth_allowed_groups )
+    default_allowed_groups = Application.get_env(:proxy, :default_mu_auth_allowed_groups)
 
-    new_headers = if authorization_groups do
-      [ { "mu-auth-allowed-groups", authorization_groups }
-        | new_headers ]
-    else
-      new_headers
+    headers_with_authorization = cond do
+      authorization_groups ->
+        [ { "mu-auth-allowed-groups", authorization_groups } | new_headers ]
+      default_allowed_groups ->
+        [ { "mu-auth-allowed-groups", default_allowed_groups } | new_headers ]
+      true ->
+        new_headers
     end
 
-    %{ conn | req_headers: new_headers }
+    %{ conn | req_headers: headers_with_authorization }
   end
 
   defp uri(conn) do


### PR DESCRIPTION
Implementation for a default `MU_AUTH_ALLOWED_GROUPS` by setting the `DEFAULT_MU_AUTH_ALLOWED_GROUPS` property as an answer to #1.

Implementation is basic but should be sufficient.  Take into account that the current implementation of the `MU_AUTH_ALLOWED_GROUPS` requires the strings to be shared.  We should therefore match the exact phrasing.  An example of what mu-authorization current outputs would be `"[{\"variables\":[],\"name\":\"public\"}]"` resulting in a setting docker-compose.yml setting like:

     environment:
       DEFAULT_MU_AUTH_ALLOWED_GROUPS: "[{\"variables\":[],\"name\":\"public\"}]"

The environment variable is currently called `DEFAULT_MU_AUTH_ALLOWED_GROUPS` but its naming should be checked and agreed on in relation to other variables and the intended naming strategy.