### PR TITLE
Consistent environment argument naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,5 +6,5 @@ The following environment variables must be configured:
 * `MU_SECRET_KEY_BASE`: base string of at least 64 bytes used to generate secret keys
 * `MU_ENCRYPTION_SALT`: a salt used with `MU_SECRET_KEY_BASE` to generate a key for encrypting/decrypting a cookie
 * `MU_SIGNING_SALT`: a salt used with `MU_SECRET_KEY_BASE` to generate a key for signing/verifying a cookie
-* `MU_CORS_HEADER`: value of the `Access-Control-Allow-Origin` header if it should be set by the identifier
-* `DEFAULT_MU_AUTH_ALLOWED_GROUPS`: string used as default `MU_AUTH_ALLOWED_GROUPS` for sessions which don't contain these groups yet. (eg: `"[{\"variables\":[],\"name\":\"public\"}]"`)
+* `DEFAULT_ACCESS_CONTROL_ALLOW_ORIGIN_HEADER`: value of the `Access-Control-Allow-Origin` header if it should be set by the identifier
+* `DEFAULT_MU_AUTH_ALLOWED_GROUPS_HEADER`: string used as default `MU_AUTH_ALLOWED_GROUPS` for sessions which don't contain these groups yet. (eg: `"[{\"variables\":[],\"name\":\"public\"}]"`)

--- a/lib/proxy.ex
+++ b/lib/proxy.ex
@@ -96,7 +96,7 @@ defmodule Proxy do
 
   defp add_cors_header( headers ) do
     # Adds the CORS header to the list of headers
-    cors_header = Application.get_env(:proxy, :cors_header)
+    cors_header = Application.get_env(:proxy, :default_access_control_allow_origin_header)
 
     if cors_header do
       put_new_key( headers, "Access-Control-Allow-Origin", cors_header )
@@ -144,7 +144,7 @@ defmodule Proxy do
         | clean_headers ]
 
     authorization_groups = Plug.Conn.get_session( conn, :mu_auth_allowed_groups )
-    default_allowed_groups = Application.get_env(:proxy, :default_mu_auth_allowed_groups)
+    default_allowed_groups = Application.get_env(:proxy, :default_mu_auth_allowed_groups_header)
 
     headers_with_authorization = cond do
       authorization_groups == "CLEAR" ->


### PR DESCRIPTION
We use environment variables for supplying default values.  Internal discussion showed that internal headers would best be named as follows:

    DEFAULT_<HEADER_NAME>_HEADER
    
In light of this, the cors- and allowed-group-header are respectively renamed to:

    DEFAULT_ACCESS_CONTROL_ALLOW_ORIGIN_HEADER
    DEFAULT_MU_AUTH_ALLOWED_GROUPS_HEADER

This change cleans up additions to the template and allows for the release to move forward.