### PR TITLE
Make logging of user sessions configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ All settings are configured through environment variables.
 * `LOG_INCOMING_ALLOWED_GROUPS`: log incoming allowed groups set on the incoming request when set to "true", "yes", "1" or "on".
 * `LOG_OUTGOING_ALLOWED_GROUPS`: log outgoing allowed groups set on the outgoing response when set to "true", "yes", "1" or "on".
 * `LOG_ALLOWED_GROUPS`: log incoming as well as outgoing allowed groups when set to "true", "yes", "1" or "on".
-
+* `LOG_SESSION_ID`: log session ids, both created as well as kept when set to "true", "yes", "1" or "on".
 
 ### Special headers
 

--- a/README.md
+++ b/README.md
@@ -167,6 +167,9 @@ All settings are configured through environment variables.
 * `LOG_OUTGOING_ALLOWED_GROUPS`: log outgoing allowed groups set on the outgoing response when set to "true", "yes", "1" or "on".
 * `LOG_ALLOWED_GROUPS`: log incoming as well as outgoing allowed groups when set to "true", "yes", "1" or "on".
 * `LOG_SESSION_ID`: log session ids, both created as well as kept when set to "true", "yes", "1" or "on".
+* `SESSION_COOKIE_SECURE`: Set SECURE flag of the session cookie (see [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie))
+* `SESSION_COOKIE_HTTP_ONLY`: Set HTTP_ONLY flag of the session cookie (see [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie)), on by default.
+* `SESSION_COOKIE_SAME_SITE`: Set SAME_SITE flag of the session cookie (see [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie)), "Lax" by default unless `DEFAULT_ACCESS_CONTROL_ALLOW_ORIGIN_HEADER` is "*" then "None" by default.  This means the cookie is available only on your site unless you've also set the CORS header.
 
 ### Special headers
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -16,7 +16,7 @@ use Mix.Config
 #       metadata: [:user_id]
 
 defmodule CH do
-  def system_boolean(name \\ default = false) do
+  def system_boolean(name, default \\ false) do
     if(!System.get_env(name)) do
       default
     else
@@ -29,6 +29,17 @@ defmodule CH do
       end
     end
   end
+
+  def calculate_same_site do
+    calculate_same_site(
+      System.get_env("DEFAULT_ACCESS_CONTROL_ALLOW_ORIGIN_HEADER"),
+      System.get_env("SESSION_COOKIE_SAME_SITE")
+    )
+  end
+
+  defp calculate_same_site(_, same_site) when is_binary(same_site), do: same_site
+  defp calculate_same_site("*", nil), do: "None"
+  defp calculate_same_site(nil, nil), do: "Lax"
 end
 
 config :mu_identifier,
@@ -38,6 +49,9 @@ config :mu_identifier,
   default_access_control_allow_origin_header:
     System.get_env("DEFAULT_ACCESS_CONTROL_ALLOW_ORIGIN_HEADER"),
   default_mu_auth_allowed_groups_header: System.get_env("DEFAULT_MU_AUTH_ALLOWED_GROUPS_HEADER"),
+  session_cookie_secure: CH.system_boolean("SESSION_COOKIE_SECURE", true),
+  session_cookie_http_only: CH.system_boolean("SESSION_COOKIE_HTTP_ONLY", true),
+  session_cookie_same_site: CH.calculate_same_site(),
   log_allowed_groups: CH.system_boolean("LOG_ALLOWED_GROUPS"),
   log_incoming_allowed_groups: CH.system_boolean("LOG_INCOMING_ALLOWED_GROUPS"),
   log_outgoing_allowed_groups: CH.system_boolean("LOG_OUTGOING_ALLOWED_GROUPS"),

--- a/config/config.exs
+++ b/config/config.exs
@@ -40,7 +40,8 @@ config :mu_identifier,
   default_mu_auth_allowed_groups_header: System.get_env("DEFAULT_MU_AUTH_ALLOWED_GROUPS_HEADER"),
   log_allowed_groups: CH.system_boolean("LOG_ALLOWED_GROUPS"),
   log_incoming_allowed_groups: CH.system_boolean("LOG_INCOMING_ALLOWED_GROUPS"),
-  log_outgoing_allowed_groups: CH.system_boolean("LOG_OUTGOING_ALLOWED_GROUPS")
+  log_outgoing_allowed_groups: CH.system_boolean("LOG_OUTGOING_ALLOWED_GROUPS"),
+  log_session: CH.system_boolean("LOG_SESSION")
 
 config :plug_mint_proxy,
   author: :"mu-semtech",

--- a/lib/manipulators/ensure_user_session.ex
+++ b/lib/manipulators/ensure_user_session.ex
@@ -7,11 +7,17 @@ defmodule Manipulators.EnsureUserSession do
 
     frontend_connection =
       if Plug.Conn.get_session(frontend_connection, :proxy_user_id) do
+        if( Application.get_env(:mu_identifier, :log_session) ) do
+          IO.inspect( Plug.Conn.get_session(frontend_connection, :proxy_user_id),
+            label: "Keeping user id" )
+        end
         frontend_connection
       else
-        IO.puts("Creating new rand user_id")
-
         new_user_id = "http://mu.semte.ch/sessions/" <> UUID.uuid1()
+
+        if( Application.get_env(:mu_identifier, :log_session) ) do
+          IO.inspect( new_user_id, label: "Created new user id" )
+        end
 
         Plug.Conn.put_session(
           frontend_connection,

--- a/lib/proxy.ex
+++ b/lib/proxy.ex
@@ -12,6 +12,9 @@ defmodule Proxy do
   plug(Plug.Session,
     store: :cookie,
     key: "proxy_session",
+    secure: Application.get_env(:mu_identifier, :session_cookie_secure),
+    http_only: Application.get_env(:mu_identifier, :session_cookie_http_only),
+    same_site: Application.get_env(:mu_identifier, :session_cookie_same_site),
     encryption_salt: @encryption_salt,
     signing_salt: @signing_salt,
     key_length: 64


### PR DESCRIPTION
The environment variable LOG_SESSION_ID can now be set to log the session ids (incoming and created).