### PR TITLE
Facilitate websocket traversal

### DIFF
--- a/lib/mu_identifier.ex
+++ b/lib/mu_identifier.ex
@@ -10,13 +10,33 @@ defmodule MuIdentifier do
     port = 80
     IO.puts("Running Proxy with Cowboy on port #{port}")
 
+    # TODO, this could be cleaner with `:cowboy.start_clear`
     children = [
-      {Secret,%{}},
-      {Plug.Cowboy, scheme: :http, plug: Proxy, options: [port: port, compress: true]}
+      {Secret, %{}},
+      {Plug.Cowboy,
+       scheme: :http, plug: Proxy, options: [dispatch: dispatch, port: port, compress: true]}
     ]
 
     Logger.info("Mu Identifier starting on port #{port}")
 
     Supervisor.start_link(children, strategy: :one_for_one)
+  end
+
+  defp dispatch do
+    default = %{
+      host: "dispatcher",
+      port: 80,
+      path: "/"
+    }
+
+    f = fn req -> default |> Map.put(:path, req.path <> "?" <> req.qs) end
+
+    [
+      {:_,
+       [
+         {"/ws/[...]", WsHandler, {f, default}},
+         {:_, Plug.Cowboy.Handler, {Proxy, []}}
+       ]}
+    ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -30,9 +30,12 @@ defmodule Proxy.Mixfile do
   # Type `mix help deps` for more examples and options
   defp deps do
     [{:plug_mint_proxy, git: "https://github.com/madnificent/plug-mint-proxy.git", tag: "v0.2.0"},
+      {:cowboy_ws_proxy, git: "https://github.com/ajuvercr/elixir-cowboy-ws-proxy-handler.git", tag: "v0.1"},
      {:uuid, "~> 1.1"},
+      {:gun, "~> 2.0.0-rc.2"},
      {:replug, "~> 0.1.0"},
      {:secure_random, "~> 0.5"},
+    {:exsync, "~> 0.2", only: :dev},
      {:observer_cli, "~> 1.5"}]
   end
 end


### PR DESCRIPTION
Makes it possible to proxy websockets to the dispatcher.

Works hand in hand with https://github.com/mu-semtech/mu-dispatcher/pull/9

