### PR TITLE
Support for overriding vary header

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -5,7 +5,7 @@ steps:
 - name: build-and-push
   image: plugins/docker
   settings:
-    repo: ${DRONE_REPO_NAMESPACE/mu-semtech/semtech}/${DRONE_REPO_NAME%-service}
+    repo: ${DRONE_REPO_NAMESPACE/mu-semtech/semtech}/${DRONE_REPO_NAME}
     username:
       from_secret: docker_username
     password:
@@ -24,7 +24,7 @@ steps:
 - name: push-feature-build
   image: plugins/docker
   settings:
-    repo: ${DRONE_REPO_NAMESPACE}/${DRONE_REPO_NAME}
+    repo: ${DRONE_REPO_NAMESPACE/mu-semtech/semtech}/${DRONE_REPO_NAME}
     tags: ${DRONE_BRANCH/\//-}
     username:
       from_secret: docker_username
@@ -33,7 +33,7 @@ steps:
     purge: true
 trigger:
   branch:
-    - feature/*
+    - '*/*'
   event:
     exclude:
       - pull_request
@@ -45,7 +45,7 @@ steps:
 - name: build-and-push-tag
   image: plugins/docker
   settings:
-    repo: ${DRONE_REPO_NAMESPACE/mu-semtech/semtech}/${DRONE_REPO_NAME%-service}
+    repo: ${DRONE_REPO_NAMESPACE/mu-semtech/semtech}/${DRONE_REPO_NAME}
     tags: ${DRONE_TAG##v} # strips v from the tag
     username:
       from_secret: docker_username
@@ -62,7 +62,7 @@ steps:
 - name: dry-run
   image: plugins/docker
   settings:
-    repo: ${DRONE_REPO_NAMESPACE/mu-semtech/semtech}/${DRONE_REPO_NAME%-service}
+    repo: ${DRONE_REPO_NAMESPACE/mu-semtech/semtech}/${DRONE_REPO_NAME}
     dry_run: true
 trigger:
   event:

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ All settings are configured through environment variables.
 * `SESSION_COOKIE_SECURE`: Set SECURE flag of the session cookie (see [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie))
 * `SESSION_COOKIE_HTTP_ONLY`: Set HTTP_ONLY flag of the session cookie (see [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie)), on by default.
 * `SESSION_COOKIE_SAME_SITE`: Set SAME_SITE flag of the session cookie (see [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie)), "Lax" by default unless `DEFAULT_ACCESS_CONTROL_ALLOW_ORIGIN_HEADER` is "*" then "None" by default.  This means the cookie is available only on your site unless you've also set the CORS header.
-* `OVERRIDE_VARY_HEADER`: EXPERIMENTAL When set, the `vary` header is overriden with the specified variable, regardless of what the backend provides.
+* `OVERRIDE_VARY_HEADER`: EXPERIMENTAL When set, the [`Vary` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Vary) is overriden with the specified variable, regardless of what the backend provides.
 
 ### Special headers
 

--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ All settings are configured through environment variables.
 * `SESSION_COOKIE_SECURE`: Set SECURE flag of the session cookie (see [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie))
 * `SESSION_COOKIE_HTTP_ONLY`: Set HTTP_ONLY flag of the session cookie (see [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie)), on by default.
 * `SESSION_COOKIE_SAME_SITE`: Set SAME_SITE flag of the session cookie (see [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie)), "Lax" by default unless `DEFAULT_ACCESS_CONTROL_ALLOW_ORIGIN_HEADER` is "*" then "None" by default.  This means the cookie is available only on your site unless you've also set the CORS header.
+* `OVERRIDE_VARY_HEADER`: EXPERIMENTAL When set, the `vary` header is overriden with the specified variable, regardless of what the backend provides.
 
 ### Special headers
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -55,7 +55,8 @@ config :mu_identifier,
   log_allowed_groups: CH.system_boolean("LOG_ALLOWED_GROUPS"),
   log_incoming_allowed_groups: CH.system_boolean("LOG_INCOMING_ALLOWED_GROUPS"),
   log_outgoing_allowed_groups: CH.system_boolean("LOG_OUTGOING_ALLOWED_GROUPS"),
-  log_session: CH.system_boolean("LOG_SESSION")
+  log_session: CH.system_boolean("LOG_SESSION"),
+  override_vary_header: System.get_env("OVERRIDE_VARY_HEADER")
 
 config :plug_mint_proxy,
   author: :"mu-semtech",

--- a/lib/manipulators/override_vary_header.ex
+++ b/lib/manipulators/override_vary_header.ex
@@ -1,0 +1,38 @@
+defmodule Manipulators.OverrideVaryHeader do
+  @behaviour ProxyManipulator
+
+  @impl true
+  def headers(headers, connection) do
+    # Adds the CORS header to the list of headers
+    has_vary_header =
+      headers
+      |> List.keyfind("vary", 0)
+
+    override_vary_header = Application.get_env(:mu_identifier, :override_vary_header)
+
+    without_vary_header =
+      headers
+      |> List.keydelete("vary", 0)
+      |> IO.inspect(label: "headers without vary")
+
+    headers =
+      if override_vary_header do
+        [{"vary", override_vary_header} | without_vary_header]
+        |> IO.inspect(label: "headers with new vary")
+      else
+        if has_vary_header do
+          [{"vary", "accept, cookie"} | without_vary_header]
+        else
+          headers
+        end
+      end
+
+    {headers, connection}
+  end
+
+  @impl true
+  def chunk(_, _), do: :skip
+
+  @impl true
+  def finish(_, _), do: :skip
+end

--- a/lib/proxy.ex
+++ b/lib/proxy.ex
@@ -25,7 +25,8 @@ defmodule Proxy do
     Manipulators.PutAllowedGroupsInSession,
     Manipulators.ClearMuInternalKeys,
     Manipulators.PutCacheClearHeaders,
-    Manipulators.AddCorsHeader
+    Manipulators.AddCorsHeader,
+    Manipulators.OverrideVaryHeader
   ]
   @manipulators ProxyManipulatorSettings.make_settings(
                   @request_manipulators,


### PR DESCRIPTION
The vary header allows to configure the request headers taken into account for caching.  This is an import part for dispatching on request-type (for example).  Because various parts of the stack emit various vary headers, it's hard for browsers to figure out what to do when.

This commit adds an override to the vary header so you can control it in a single location and get some more sanity into the approach.  It's experimental, it may go away, and it may well be that we find better approaches to handle this in different parts of the stack.  For now, this may help to solve practical cases.

The documentation clearly describes this to be experimental.  There's a good shot this is moved to the dispatcher, especially if/when more specific directives would be offered there.