### PR TITLE
Replace Cowboy with Bandit

### DIFF
--- a/lib/mu_identifier.ex
+++ b/lib/mu_identifier.ex
@@ -8,18 +8,14 @@ defmodule MuIdentifier do
 
   def start(_argv, _args) do
     port = 80
-    IO.puts("Running Proxy with Cowboy on port #{port}")
+    IO.puts("Running Proxy with Bandit on port #{port}")
 
     children = [
       {Secret, %{}},
-      {Plug.Cowboy,
+      {Bandit,
        scheme: :http,
        plug: Proxy,
-       options: [
-         port: port,
-         compress: true,
-         protocol_options: [idle_timeout: Application.get_env(:mu_identifier, :idle_timeout)]
-       ]}
+       port: port}
     ]
 
     Logger.info("Mu Identifier starting on port #{port}")

--- a/mix.exs
+++ b/mix.exs
@@ -13,7 +13,7 @@ defmodule Proxy.Mixfile do
   # Type `mix help compile.app` for more information
   def application do
     [
-      extra_applications: [:logger, :plug_mint_proxy, :cowboy, :plug],
+      extra_applications: [:logger, :plug_mint_proxy, :plug],
       mod: {MuIdentifier, []},
       env: []
     ]
@@ -30,6 +30,7 @@ defmodule Proxy.Mixfile do
   # Type `mix help deps` for more examples and options
   defp deps do
     [{:plug_mint_proxy, git: "https://github.com/madnificent/plug-mint-proxy.git", tag: "v0.2.0"},
+     {:bandit, "0.7.7" },
      {:uuid, "~> 1.1"},
      {:replug, "~> 0.1.0"},
      {:secure_random, "~> 0.5"},

--- a/mix.exs
+++ b/mix.exs
@@ -29,7 +29,7 @@ defmodule Proxy.Mixfile do
   #
   # Type `mix help deps` for more examples and options
   defp deps do
-    [{:plug_mint_proxy, git: "https://github.com/madnificent/plug-mint-proxy.git", tag: "v0.2.0"},
+    [{:plug_mint_proxy, git: "https://github.com/madnificent/plug-mint-proxy.git", tag: "v0.3.0"},
      {:bandit, "0.7.7" },
      {:uuid, "~> 1.1"},
      {:replug, "~> 0.1.0"},


### PR DESCRIPTION
Remove the Cowboy dependency and instantiate a [Bandit](https://github.com/mtrudel/bandit) plug instead of a Cowboy plug. According to the Bandit docs, it should in general be a drop-in replacement for Plug.Cowboy. Note that we don't pass a compress option to the Bandit plug because Bandit should enable compression by default according to [the docs](https://hexdocs.pm/bandit/Bandit.html).

:warning: **This requires a bump of the plug dependency in plug_mint_proxy!** See related PR below:
- https://github.com/madnificent/plug-mint-proxy/pull/2

Some context: the identifier (and dispatcher) currently use Cowboy to provide a HTTP server where clients can connect. While it works, it has some quirks w.r.t. [timing out ongoing requests](https://github.com/ninenines/cowboy/issues/1278). In Kaleidos we notice this when serving large files. Clients' downloads will abruptly end mid-stream because the identifier closes the connection due to Cowboy's behaviour. We can mitigate this by raising the `idle_timeout` setting of Cowboy, but there will always be a cut-off point for long lasting HTTP requests. Based on local testing, Bandit does not seem to have this behaviour.