### PR TITLE
add support for private network access cors header

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ All settings are configured through environment variables.
 ### Environment variables
 
 * `DEFAULT_ACCESS_CONTROL_ALLOW_ORIGIN_HEADER`: value of the `Access-Control-Allow-Origin` header if none is set by the backend.
+* `ALLOW_PRIVATE_NETWORK_ACCESS`: when set to "true", "yes", "1" or "on", adds the `Access-Control-Allow-Private-Network: true` header to all responses. Required when a browser on a public network accesses this service on a private network (see [Private Network Access](https://developer.chrome.com/blog/private-network-access-preflight/)).
 * `DEFAULT_MU_AUTH_ALLOWED_GROUPS_HEADER`: string used as default `Mu-Auth-Allowed-Groups` for sessions which don't contain these groups yet and which may use defaults (eg: `"[{\"variables\":[],\"name\":\"public\"}]"`).
 * `MU_SECRET_KEY_BASE`: base string of base string of at least 64 bytes used to generate secret keys, set this on production systems to avoid overlap.
 * `MU_ENCRYPTION_SALT`: a salt used with `MU_SECRET_KEY_BASE` to generate a key for encrypting/decrypting a cookie, set this on production systems so sessions survive restarts of the identifier.

--- a/config/config.exs
+++ b/config/config.exs
@@ -57,7 +57,8 @@ config :mu_identifier,
   log_outgoing_allowed_groups: CH.system_boolean("LOG_OUTGOING_ALLOWED_GROUPS"),
   log_session: CH.system_boolean("LOG_SESSION"),
   idle_timeout: System.get_env("IDLE_TIMEOUT", "300000") |> String.to_integer,
-  override_vary_header: System.get_env("OVERRIDE_VARY_HEADER")
+  override_vary_header: System.get_env("OVERRIDE_VARY_HEADER"),
+  allow_private_network_access: CH.system_boolean("ALLOW_PRIVATE_NETWORK_ACCESS")
 
 config :plug_mint_proxy,
   author: :"mu-semtech",

--- a/lib/manipulators/add_cors_header.ex
+++ b/lib/manipulators/add_cors_header.ex
@@ -13,6 +13,13 @@ defmodule Manipulators.AddCorsHeader do
         headers
       end
 
+    headers =
+      if Application.get_env(:mu_identifier, :allow_private_network_access) do
+        put_new_key(headers, "Access-Control-Allow-Private-Network", "true")
+      else
+        headers
+      end
+
     { headers, connection }
   end
 


### PR DESCRIPTION
PNA (private network access) is a fairly recent addition that is now enforced in most browsers. a CORS request from a public page to a page on a private network is blocked unless private network access is explicitely allowed via a CORS header.

Generally this is a good thing, but there are cases where it can be useful to allow it:
- test setups where one app recides on a public ip and the other on a private ip
- corporate networks where a subset of domains map to internal ips for performance reasons

Background: https://wicg.github.io/private-network-access/